### PR TITLE
Update README.md with specs for MEMS microphones and RGB LED components

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ For more information about the concept/idea see and contribute to related discus
 - Dual SPI flash
 - Dual I²S buses (to allow I2S interfaces at the same time, i.e. simultaneous audio output and audio input)
 - MAX98357 for speaker output (I2S Class-D Mono Audio Amplifyer)
-- 2x MEMS microphones (MSM261DHP)
-- SK6812 LEDs
+- 2x MEMS microphones (dual MSM261DHP with 68mm inter-mic spacing)
+- 4x SK6812 RGB LEDs
 - Custom USB-C and 14V power input
 
 ---


### PR DESCRIPTION
Add specs for both MEMS microphones and RGB LED components to the list of known hardware specifications in readme file:

```
- 2x MEMS microphones (dual MSM261DHP with 68mm inter-mic spacing)
- 4x SK6812 RGB LEDs
```

Replaces PR https://github.com/iMike78/nest-mini-drop-in-pcb/pull/19